### PR TITLE
Handle build name

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,3 @@
 [
-    { "keys": ["super+b"], "command": "build_switcher" }
+    { "keys": ["ctrl+b"], "command": "build_switcher" }
 ]

--- a/README.md
+++ b/README.md
@@ -13,16 +13,32 @@ There is currently no way to get list of available build systems in [Sublime], s
 ````
 {
     "settings": {
-        "build_switcher_systems": ["Unit tests", "CoffeeScript"]
+        "build_switcher_systems": [
+            "Unit tests",
+            "CoffeeScript"
+            ["My unit tests", "c:\\builds\\UI_tests.sublime-build"],
+            ["My CoffeeScript", "/Users/me/build/coffee.sublime-build"]
+        ]
     }
 }
 ````
+
+You can provide either build name only or custom name and build file path.
 
 If you don't specify any build system, BuildSwitcher will just execute the currently selected build (the same behavior as Sublime's default `super+b` shortcut).
 
 If you specify only one build system, it will execute it without asking.
 
 If you specify multiple systems, you always get a pop up with options (sorted by usage).
+
+
+Build variants can be specified by separating them from the build name using a pound sign “#.
+
+So configuring:
+
+"build_switcher_systems": ["Make", "Make#Install", ["MyMake#Install", "/Users/me/make.sublime-build"]]
+
+and then choosing “Make#Install” will trigger the Make build system in the “Install” variant.
 
 ## Defining key shortcut
 By default, "build_switcher" is mapped to `CMD+B`, however you can easily change that, just add to your keymap preferences:

--- a/build_switcher.py
+++ b/build_switcher.py
@@ -34,9 +34,15 @@ class BuildSwitcherCommand(WindowCommand):
         # the dialog was cancelled
         if idx is -1: return
 
-        system = self.available_systems[idx].partition("#")
+        item = self.available_systems[idx]
+        if isinstance(item, list):
+            system = item[0].partition("#")
+            build = item[1]
+        else:
+            system = item.partition("#")
+            build = system[0]
 
-        self.window.run_command("set_build_system", {"file": system[0]})
+        self.window.run_command("set_build_system", {"file": build})
         if system[1]:
             self.window.run_command("build", {"variant": system[2]})
         else:


### PR DESCRIPTION
I've added build name - full path displayed in popup is not clear, especially if You have several build scripts in same location. 
Also fixed default shortcut mapping on windows. 
