### PR TITLE
issue fix for active_view().settings() in __init__

### DIFF
--- a/build_switcher.py
+++ b/build_switcher.py
@@ -6,11 +6,6 @@ class BuildSwitcherCommand(WindowCommand):
     def __init__(self, window):
         WindowCommand.__init__(self, window)
 
-        settings = self.window.active_view().settings()
-        settings.add_on_change("build_switcher_systems", self._reload_settings)
-        self._reload_settings()
-
-
     def _reload_settings(self):
         settings = self.window.active_view().settings()
         self.available_systems = settings.get("build_switcher_systems")
@@ -18,6 +13,10 @@ class BuildSwitcherCommand(WindowCommand):
 
     def run(self):
         win = self.window
+
+        settings = self.window.active_view().settings()
+        settings.add_on_change("build_switcher_systems", self._reload_settings)
+        self._reload_settings()
 
         if not self.available_systems:
             # no switcher builds - just do selected build


### PR DESCRIPTION
i had an issue on windows where `self.window.active_view().settings()` in the `__init__` method returned a `NoneType` which raised the following message in the console, "AttributeError: 'NoneType' object has no attribute 'settings'".

the result was that build switcher and package control stopped working altogether.

i moved the settings code block from `__init__` to `run` and it fixed my issue.
